### PR TITLE
fixed strings to have quotes to properly identify

### DIFF
--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -59,7 +59,7 @@ module MotionPrint
         else
           v = logger(value)
         end
-        out << (align(key, width, indent_level) << colorize(" => ", :hash) << v)
+        out << (align(key, width, indent_level) << hash_rocket << v)
       end
 
       "{\n" << out.join(",\n") << "\n#{indent_by(indent_level-1)}}"
@@ -71,12 +71,16 @@ module MotionPrint
     end
 
     def l_symbol(object)
-      colorize(':' << object.to_s, object)
+      colorize(object, object)
     end
 
     def colorize(object, type = nil)
       type = object if type.nil?
-      Colorizer.send(decide_color(type), object)
+      Colorizer.send(decide_color(type), object.inspect)
+    end
+
+    def hash_rocket
+      Colorizer.send(decide_color(:hash), " => ")
     end
 
     def decide_color(object)

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -32,16 +32,16 @@ describe "motion_print gem" do
     # Numbers
     MotionPrint.logger([1, 2]).should == "[\n  \e[1;34m1\e[0m,\n  \e[1;34m2\e[0m\n]"
     # Strings
-    MotionPrint.logger(['1', '2']).should == "[\n  \e[0;33m1\e[0m,\n  \e[0;33m2\e[0m\n]"
+    MotionPrint.logger(['1', '2']).should == "[\n  \e[0;33m\"1\"\e[0m,\n  \e[0;33m\"2\"\e[0m\n]"
   end
 
   it 'outputs multidimensional arrays properly' do
     # Numbers and Strings
-    MotionPrint.logger([1, 2, ['1', '2']]).should == "[\n  \e[1;34m1\e[0m,\n  \e[1;34m2\e[0m,\n  [\n    \e[0;33m1\e[0m,\n    \e[0;33m2\e[0m\n  ]\n]"
+    MotionPrint.logger([1, 2, ['1', '2']]).should == "[\n  \e[1;34m1\e[0m,\n  \e[1;34m2\e[0m,\n  [\n    \e[0;33m\"1\"\e[0m,\n    \e[0;33m\"2\"\e[0m\n  ]\n]"
   end
 
   it 'outputs hashes properly' do
-    MotionPrint.logger({a: 'a', b: 2}).should == "{\n  \e[0;36m:a\e[0m  \e[0;36m => \e[0m\e[0;33ma\e[0m,\n  \e[0;36m:b\e[0m  \e[0;36m => \e[0m\e[1;34m2\e[0m\n}"
+    MotionPrint.logger({a: 'a', b: 2}).should == "{\n  \e[0;36m:a\e[0m  \e[0;36m => \e[0m\e[0;33m\"a\"\e[0m,\n  \e[0;36m:b\e[0m  \e[0;36m => \e[0m\e[1;34m2\e[0m\n}"
   end
 
   it 'outputs hashes with arrays properly' do
@@ -53,7 +53,7 @@ describe "motion_print gem" do
         12,
         String
       ]
-    }).should == "{\n  \e[0;36m:a\e[0m  \e[0;36m => \e[0m\e[0;33ma\e[0m,\n  \e[0;36m:b\e[0m  \e[0;36m => \e[0m\e[1;34m2\e[0m,\n  \e[0;36m:c\e[0m  \e[0;36m => \e[0m[\n    \e[1;34m4.4\e[0m,\n    \e[1;34m12\e[0m,\n    \e[1;33mString\e[0m\n  ]\n}"
+    }).should == "{\n  \e[0;36m:a\e[0m  \e[0;36m => \e[0m\e[0;33m\"a\"\e[0m,\n  \e[0;36m:b\e[0m  \e[0;36m => \e[0m\e[1;34m2\e[0m,\n  \e[0;36m:c\e[0m  \e[0;36m => \e[0m[\n    \e[1;34m4.4\e[0m,\n    \e[1;34m12\e[0m,\n    \e[1;33mString\e[0m\n  ]\n}"
   end
 
   it 'outputs numbers correctly' do


### PR DESCRIPTION
When you output strings you're losing quotes on them, making us have to remember the color for strings and causing your hash outputs to be somewhat false.

`:some_symbol => string` should be `:some_symbol => "string"`

Here's the fix!  :)  with updated tests.
