### PR TITLE
Use NSLog when printing on the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ And then execute:
 ```bash
 bundle
 ```
+
+## Enabling NSLog on the Device
+
+Normally, `mp` will not print output when the app is run on the device. To enable output via NSLog, use `MotionPrint.enable_nslog`:
+
+```ruby
+def application(application, didFinishLaunchingWithOptions:launchOptions)
+  #...
+  MotionPrint.enable_nslog
+  #...
+end
+```
+
 ## Fancy Debugging Tips
 
 Ruby comes with some great methods for method introspection.  These methods look great in motion_print.

--- a/motion/motion_print/core_ext/kernel.rb
+++ b/motion/motion_print/core_ext/kernel.rb
@@ -1,6 +1,12 @@
 module Kernel
   def mp(object, options = {})
-    puts MotionPrint.logger(object)
+    logger = MotionPrint.logger(object)
+
+    if MotionPrint.simulator?
+      puts logger
+    else
+      logger.split("\n").each { |line| NSLog(line) }
+    end
     object unless MotionPrint.console?
   end
 

--- a/motion/motion_print/core_ext/kernel.rb
+++ b/motion/motion_print/core_ext/kernel.rb
@@ -4,7 +4,7 @@ module Kernel
 
     if MotionPrint.simulator?
       puts logger
-    else
+    elsif MotionPrint.nslog_enabled?
       logger.split("\n").each { |line| NSLog(line) }
     end
     object unless MotionPrint.console?

--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -5,6 +5,10 @@ module MotionPrint
       !!defined?(MotionRepl)
     end
 
+    def simulator?
+      @simulator ||= !(UIDevice.currentDevice.model =~ /simulator/i).nil?
+    end
+
     def cdq_object
       return CDQManagedObject if defined? CDQManagedObject
     end

--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -5,6 +5,14 @@ module MotionPrint
       !!defined?(MotionRepl)
     end
 
+    def enable_nslog
+      @nslog_enabled = true
+    end
+
+    def nslog_enabled?
+      !@nslog_enabled.nil?
+    end
+
     def simulator?
       @simulator ||= !(UIDevice.currentDevice.model =~ /simulator/i).nil?
     end

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -78,6 +78,12 @@ describe "motion_print gem" do
     MotionPrint.simulator?.should == !(UIDevice.currentDevice.model =~ /simulator/i).nil?
   end
 
+  it 'allows opt-in for NSLog behavior' do
+    MotionPrint.nslog_enabled?.should == false
+    MotionPrint.enable_nslog
+    MotionPrint.nslog_enabled?.should == true
+  end
+
   describe "CDQ Object Handling" do
     # Mock CDQ object
     before do

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -73,6 +73,11 @@ describe "motion_print gem" do
     MotionPrint.logger(false).should == "\e[1;31mfalse\e[0m"
   end
 
+  it 'detects the simulator correctly' do
+    MotionPrint.respond_to?(:simulator?).should == true
+    MotionPrint.simulator?.should == !(UIDevice.currentDevice.model =~ /simulator/i).nil?
+  end
+
   describe "CDQ Object Handling" do
     # Mock CDQ object
     before do


### PR DESCRIPTION
This PR updates `Kernel#mp()` to use NSLog when running on the device as discussed in https://github.com/OTGApps/motion_print/issues/6

It basically just splits on newlines the output that would have been printed using `puts` on the simulator and prints each line using NSLog. I was skeptical this would work initially, but it seems to work pretty well in my limited testing.

I took the guts of `MotionPrint.simulator?` directly from BubbleWrap::Device, and it should be cached as a class instance variable and thus be pretty lightweight to call in repeated calls to `Kernel#mp()`. I added a spec for `MotionPrint.simulator?` that passes on both the simulator and the device. However, I have no idea how to test the actual NSLog part. I didn't want to add a mocking/stubbing library, and I'm pretty sure NSLog would be a hard thing to stub/spy on, regardless. Suggestions welcome on that front.

Anyway, please take a look and let me know if this is something worth pursuing. 

Cheers,

Mark
