### PR TITLE
use $stderr for test output so we can see mp there

### DIFF
--- a/motion/motion_print/core_ext/kernel.rb
+++ b/motion/motion_print/core_ext/kernel.rb
@@ -1,6 +1,7 @@
 module Kernel
   def mp(object, options = {})
-    puts MotionPrint.logger(object)
+    output_stream = RUBYMOTION_ENV == "test" ? $stderr : $stdout
+    output_stream.puts MotionPrint.logger(object)
     object unless MotionPrint.console?
   end
 


### PR DESCRIPTION
Tests suppress $stdout output, so using $stderr during tests will show them.

Does it make sense to use $stderr all the time for mp output?
