### PR TITLE
Adds "Opt-in" support to Motion Print

### DIFF
--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -15,6 +15,17 @@ module MotionPrint
         force_color: nil
       }.merge(options)
 
+      if object.respond_to?(:motion_print)
+        arity = object.method(:motion_print).arity
+        if arity == 1
+          return object.motion_print(self)
+        elsif arity == 2
+          return object.motion_print(self, options)
+        else
+          return colorize(object.motion_print)
+        end
+      end
+
       case object
       when nil
         colorize(object, options[:force_color])

--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -15,17 +15,6 @@ module MotionPrint
         force_color: nil
       }.merge(options)
 
-      if object.respond_to?(:motion_print)
-        arity = object.method(:motion_print).arity
-        if arity == 1
-          return object.motion_print(self)
-        elsif arity == 2
-          return object.motion_print(self, options)
-        else
-          return colorize(object.motion_print)
-        end
-      end
-
       case object
       when nil
         colorize(object, options[:force_color])
@@ -44,7 +33,7 @@ module MotionPrint
       when cdq_object
         l_cdq(object, options)
       else
-        colorize(object, options[:force_color])
+        l_custom(object, options)
       end
     end
 
@@ -101,6 +90,21 @@ module MotionPrint
     end
 
     def l_symbol(object, options)
+      colorize(object, options[:force_color])
+    end
+
+    def l_custom(object, options)
+      if object.respond_to?(:motion_print)
+        case object.method(:motion_print).arity
+        when 1
+          return object.motion_print(self)
+        when 2
+          return object.motion_print(self, options)
+        else
+          return colorize(object.motion_print)
+        end
+      end
+
       colorize(object, options[:force_color])
     end
 

--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -101,7 +101,7 @@ module MotionPrint
         when 2
           return object.motion_print(self, options)
         else
-          return colorize(object.motion_print)
+          return colorize(object.motion_print, options[:force_color])
         end
       end
 

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -89,15 +89,15 @@ describe "motion_print gem" do
   end
 
   it 'outputs string correctly' do
-    MotionPrint.logger('boo!').should == "\e[0;33mboo!\e[0m"
+    MotionPrint.logger('boo!').should == "\e[0;33m\"boo!\"\e[0m"
   end
 
   it 'outputs string with newlines correctly' do
-    MotionPrint.logger("a\nb\nc").should == "\e[0;33ma\nb\nc\e[0m"
+    MotionPrint.logger("a\nb\nc").should == "\e[0;33m\"a\\nb\\nc\"\e[0m"
   end
 
   it 'outputs string with newlines indented correctly' do
-    MotionPrint.logger(["a\nb\nc"], 2).should == "[\n    \e[0;33ma\n    b\n    c\e[0m\n]"
+    MotionPrint.logger(["a\nb\nc"], indent_level: 2).should == "[\n    \e[0;33m\"a\\nb\\nc\"\e[0m\n  ]"
   end
 
   describe "CDQ Object Handling" do

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -88,6 +88,18 @@ describe "motion_print gem" do
     MotionPrint.logger(false).should == "\e[1;31mfalse\e[0m"
   end
 
+  it 'outputs string correctly' do
+    MotionPrint.logger('boo!').should == "\e[0;33mboo!\e[0m"
+  end
+
+  it 'outputs string with newlines correctly' do
+    MotionPrint.logger("a\nb\nc").should == "\e[0;33ma\nb\nc\e[0m"
+  end
+
+  it 'outputs string with newlines indented correctly' do
+    MotionPrint.logger(["a\nb\nc"], 2).should == "[\n    \e[0;33ma\n    b\n    c\e[0m\n]"
+  end
+
   describe "CDQ Object Handling" do
     # Mock CDQ object
     before do

--- a/spec/opt_in_spec.rb
+++ b/spec/opt_in_spec.rb
@@ -30,6 +30,9 @@ describe 'opt in motion_print support' do
     it 'should support motion_print, arity == 0' do
       MotionPrint.logger(SimpleMotionPrint.new).should == "\e[0;33m\"SimpleMotionPrint\"\e[0m"
     end
+    it 'should support motion_print, arity == 0, with options' do
+      MotionPrint.logger(SimpleMotionPrint.new, force_color: :blue).should == "\e[1;34m\"SimpleMotionPrint\"\e[0m"
+    end
   end
   describe CustomMotionPrint do
     it 'should support motion_print, arity == 1' do

--- a/spec/opt_in_spec.rb
+++ b/spec/opt_in_spec.rb
@@ -1,0 +1,44 @@
+class SimpleMotionPrint
+
+  def motion_print
+    'SimpleMotionPrint'
+  end
+
+end
+
+
+class CustomMotionPrint
+
+  def motion_print(mp)
+    mp.colorize('CustomMotionPrint', :cyanish)
+  end
+
+end
+
+
+class IndentedMotionPrint
+
+  def motion_print(mp, options)
+    mp.logger(['Indented', 'Motion', 'Print'], options)
+  end
+
+end
+
+
+describe 'opt in motion_print support' do
+  describe SimpleMotionPrint do
+    it 'should support motion_print, arity == 0' do
+      MotionPrint.logger(SimpleMotionPrint.new).should == "\e[0;33m\"SimpleMotionPrint\"\e[0m"
+    end
+  end
+  describe CustomMotionPrint do
+    it 'should support motion_print, arity == 1' do
+      MotionPrint.logger(CustomMotionPrint.new).should == "\e[0;36m\"CustomMotionPrint\"\e[0m"
+    end
+  end
+  describe IndentedMotionPrint do
+    it 'should support motion_print, arity == 2' do
+      MotionPrint.logger(IndentedMotionPrint.new).should == "[\n  \e[0;33m\"Indented\"\e[0m,\n  \e[0;33m\"Motion\"\e[0m,\n  \e[0;33m\"Print\"\e[0m\n]"
+    end
+  end
+end


### PR DESCRIPTION
Per discussion #9, this adds a check for whether the printed object implements a `motion_print` method, and if so, calls that method.  Depending on the arity of the method, it will call it:

1. with the `MotionPrint` object (class instance)
2. with `MotionPrint` and options
3. otherwise, it is called with no arguments

Usage:

```ruby
class CDQManagedObject
  def motion_print(mp, options)
      if respond_to? :attributes
        "OID: " + mp.colorize(oid.gsub('"',''), options[:force_color]) + "\n" + mp.l_hash(attributes, options)
      else
        # old colorless method, still more informative than nothing
        log
      end
  end
end
```

CC @GantMan @jamonholmgren 
