### PR TITLE
added support for OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
     - bundle install
     - bundle exec rake clean
     - bundle exec rake spec
+    - bundle exec rake spec platform=osx

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project/template/ios'
+platform = ENV.fetch('platform', 'ios')
+require "motion/project/template/#{platform}"
 require 'bundler/gem_tasks'
 require 'bundler/setup'
 Bundler.require
@@ -9,8 +10,10 @@ Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'motion_print'
   app.identifier = 'io.otgapps.motion_print'
-  app.device_family = [:iphone, :ipad]
-  app.prerendered_icon = true
-  app.interface_orientations = [:portrait, :landscape_left, :landscape_right, :portrait_upside_down]
+  if app.template == 'ios'
+    app.device_family = [:iphone, :ipad]
+    app.prerendered_icon = true
+    app.interface_orientations = [:portrait, :landscape_left, :landscape_right, :portrait_upside_down]
+  end
   app.frameworks += %w(QuartzCore CoreGraphics)
 end

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -1,7 +1,12 @@
 class AppDelegate
+  # iOS entry point
   def application(application, didFinishLaunchingWithOptions:launchOptions)
     return true if RUBYMOTION_ENV == 'test'
 
     true
+  end
+
+  # OS X entry point
+  def applicationDidFinishLaunching(notification)
   end
 end

--- a/spec/colorizer.rb
+++ b/spec/colorizer.rb
@@ -20,7 +20,7 @@ describe 'colorizer' do
       {rubymotion: "rocks!"},
       Time.now,
       Object.new,
-      UIView.new,
+      NSSet.new,
       4,
       12.0,
       true


### PR DESCRIPTION
Made changes to allow usage and testing for OS X apps.  To test, just do `rake spec platform=osx`.  The default platform is iOS.