### PR TITLE
Show formatted instance variables when available...

### DIFF
--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -8,7 +8,8 @@ module MotionPrint
     def logger(object, options = {})
       options = {
         indent_level: 1,
-        force_color: nil
+        force_color: nil,
+        ivar: true
       }.merge(options)
 
       case object
@@ -87,9 +88,36 @@ module MotionPrint
         else
           return colorize(object.motion_print, options[:force_color])
         end
+      elsif object.respond_to?(:instance_variables) && !object.instance_variables.empty?
+        return l_instance_variables(object, options)
       end
 
       colorize(object, options[:force_color])
+    end
+
+    # Output a list of instance variables.  only allows one level to avoid excessive output
+    # and circular references. Will also show a different color for instance variables that
+    # have accessors or not.
+    def l_instance_variables(object, options)
+      ivars = object.instance_variables.reject {|item| !item.to_s.start_with?('@')} # only allow proper instance variables
+      return colorize(object, options[:force_color]) if !options[:ivar] || ivars.empty?
+      data  = []
+      out   = [colorize(object.class, options[:force_color])]
+
+      ivars.each do |ivar|
+        use_color = object.respond_to?(ivar.to_s[1..-1]) ? colors[:method] : colors[:ivar]
+        data     << [logger(ivar, options.merge({force_color: specific_color(use_color, options)})), ivar]
+      end
+
+      width  = data.map { |ivar_str, | ivar_str.size }.max || 0
+      width += indent_by(options[:indent_level]).length
+      
+      data.each do |ivar_str, ivar|
+        out << (align(ivar_str, width, options[:indent_level]) << hash_rocket(options[:force_color]) <<
+                logger(object.instance_variable_get(ivar), options.merge({ivar: false, force_color: specific_color(:pale, options)})))
+      end
+
+      out.join("\n") << "\n#{indent_by(options[:indent_level] - 1)}"
     end
 
     def colorize(object, force_color = nil)
@@ -102,6 +130,10 @@ module MotionPrint
 
     def decide_color(object)
       colors[object.class.to_s.downcase.to_sym] || :white
+    end
+    
+    def specific_color(color, options)
+      options[:force_color] || color
     end
 
     def colors
@@ -125,7 +157,8 @@ module MotionPrint
         time:       :greenish,
         trueclass:  :green,
         variable:   :cyanish,
-        dir:        :white
+        dir:        :white,
+        ivar:       :cyanish
       }
     end
 

--- a/motion/motion_print/motion_print.rb
+++ b/motion/motion_print/motion_print.rb
@@ -102,7 +102,7 @@ module MotionPrint
       ivars = object.instance_variables.reject {|item| !item.to_s.start_with?('@')} # only allow proper instance variables
       return colorize(object, options[:force_color]) if !options[:ivar] || ivars.empty?
       data  = []
-      out   = [colorize(object.class, options[:force_color])]
+      out   = [class_address(object, options[:force_color])]
 
       ivars.each do |ivar|
         use_color = object.respond_to?(ivar.to_s[1..-1]) ? colors[:method] : colors[:ivar]
@@ -126,6 +126,10 @@ module MotionPrint
 
     def hash_rocket(force_color = nil)
       Colorizer.send(force_color || decide_color(:hash), " => ")
+    end
+
+    def class_address(object, force_color = nil)
+      Colorizer.send(force_color || colors[:class], "#<#{object.class}:0x%08x>" % (object.object_id))
     end
 
     def decide_color(object)

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -108,7 +108,9 @@ describe "motion_print gem" do
       end
     end
     ivar = Foo.new
-    MotionPrint.logger(ivar).should == "\e[1;33mFoo\e[0m\n  \e[0;35m:@bar1\e[0m  \e[0;36m => \e[0m\e[0;37m1\e[0m\n  \e[0;36m:@bar2\e[0m  \e[0;36m => \e[0m\e[0;37m2\e[0m\n"
+    # MotionPrint.logger(ivar).should == "\e[1;33mFoo\e[0m\n  \e[0;35m:@bar1\e[0m  \e[0;36m => \e[0m\e[0;37m1\e[0m\n  \e[0;36m:@bar2\e[0m  \e[0;36m => \e[0m\e[0;37m2\e[0m\n"
+    MotionPrint.logger(ivar).start_with?("\e[1;33m#<Foo:0x").should == true
+    MotionPrint.logger(ivar).end_with?(">\e[0m\n  \e[0;35m:@bar1\e[0m  \e[0;36m => \e[0m\e[0;37m1\e[0m\n  \e[0;36m:@bar2\e[0m  \e[0;36m => \e[0m\e[0;37m2\e[0m\n").should == true
   end
 
 end

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -100,4 +100,16 @@ describe "motion_print gem" do
     MotionPrint.logger(["a\nb\nc"], indent_level: 2).should == "[\n    \e[0;33m\"a\\nb\\nc\"\e[0m\n  ]"
   end
 
+  it 'outputs instance variables properly' do
+    class Foo
+      attr_accessor :bar1
+      def initialize
+        @bar1, @bar2 = 1, 2
+      end
+    end
+    ivar = Foo.new
+    MotionPrint.logger(ivar).should == "\e[1;33mFoo\e[0m\n  \e[0;35m:@bar1\e[0m  \e[0;36m => \e[0m\e[0;37m1\e[0m\n  \e[0;36m:@bar2\e[0m  \e[0;36m => \e[0m\e[0;37m2\e[0m\n"
+  end
+
 end
+


### PR DESCRIPTION
Love how motion_print nicely formats many classes.

One thing I've always wanted was to have better output of the instance variables that are shown by default when you output a class.  For example, doing `NSApplication.sharedApplication.delegate` gives something like

```
#<AppDelegate:0x100c9f8a0 @main_window=#<NSWindow:0x105f5af80> @main_controller=#
<MainController:0x105f709a0> @toolbar_item_file_title=#<NSToolbarItem:0x10b09d270> 
@tool_bar=#<NSToolbar:0x10afd2f90> @appearance_observer=#<__NSObserver:0x100d55850>>
```

What I would like to see is something like this (colorized of course):

```
AppDelegate
  :@main_window               => #<NSWindow:0x105f5af80>
  :@main_controller           => #<MainController:0x105f709a0>
  :@tool_bar                  => #<NSToolbar:0x10afd2f90>
  :@appearance_observer       => #<__NSObserver:0x100d55850>
```

So I've created the attached PR to implement this.  It doesn't effect any classes that implement the `motion_print` hook.  It also colorizes differently any instance variable that has public accessor method; makes it easy to know whether or not you can directly inspect that variable or not.

Hope you find it useful...
